### PR TITLE
Add test to detect hardcoded return values

### DIFF
--- a/01-Ruby/01-Programming-basics/01-Experiment-methods/spec/experiment_spec.rb
+++ b/01-Ruby/01-Programming-basics/01-Experiment-methods/spec/experiment_spec.rb
@@ -6,6 +6,7 @@ describe "#get_rid_of_surrounding_whitespaces" do
 
   it "should get rid of both leading and trailing whitespaces" do
     expect( get_rid_of_surrounding_whitespaces("  hey yo  ") ).to eq("hey yo")
+    expect( get_rid_of_surrounding_whitespaces("nice try!") ).to eq("nice try!")
   end
 
 end


### PR DESCRIPTION
Some students can "cheat" their way through the very first exercise by hardcoding the result `"hey joe"` which give them false hopes (and a false start) as it shows that they did not understand what a method is supposed to do and what is actually expected from them (the rake workflow).

Students can of course fake other exercises but I think it's better to make sure their very first attempt explicitly fails instead of having to tell them that even though the "rake is green", that their code is not right. They should be able to trust the output of rake, especially on their very first attempt. 
