### PR TITLE
Fix ruby code example typo in README

### DIFF
--- a/00-Setup/01-Submit-your-code/README.md
+++ b/00-Setup/01-Submit-your-code/README.md
@@ -17,7 +17,7 @@ Working in pairs is a common practice of Software Engineering. The idea is that 
 
 Open the `lib/wagon_start.rb` file. That's where you'll need to edit
 
-* Make the `wagon_start` method return `'That's how it starts'`
+* Make the `wagon_start` method return `"That's how it starts"`
 * In the terminal, run `rake` and make sure if you're 100% green + have a good style.
 * Commit your changes, and push them.
 * Come back to Kitt, and refresh the page. You should see your solution on the right


### PR DESCRIPTION
The method should return with `"` as the string contains a `'`