### PR TITLE
Fix deprecation warning: rspec custom message API change

### DIFF
--- a/03-AR-Database/04-ActiveRecord-Advanced/02-Validations/spec/models/user_spec.rb
+++ b/03-AR-Database/04-ActiveRecord-Advanced/02-Validations/spec/models/user_spec.rb
@@ -42,7 +42,7 @@ describe "User" do
     end
     user = User.new(username: "bob", email: "   bob@leponge.me   ")
     expect(user.valid?).to eq(true)
-    expect(user.email).to eq("bob@leponge.me"), message: "You should have a `before_validation` callback to strip whitespaces"
+    expect(user.email).to eq("bob@leponge.me"), "You should have a `before_validation` callback to strip whitespaces"
   end
 
 end


### PR DESCRIPTION
Custom messages can now be given as-is instead of via a `message:` key.
See: https://relishapp.com/rspec/rspec-expectations/docs/customized-message

Students were freaked out by the loud deprecation warning in the middle of their green rake output. ;)